### PR TITLE
Add tag name argument to graminize

### DIFF
--- a/openfl/interface/workspace.py
+++ b/openfl/interface/workspace.py
@@ -441,6 +441,12 @@ def dockerize_(context, base_image, save):
              'Must be a power-of-2.\n'
              'Default is 16G.'
         )
+@option('-t', '--tag', required=False,
+        type=str, multiple=False, default='{workspace_name}',
+        help='Tag of the created Docker image. '
+             '"{workspace_name}" is used as a placeholder for workspace name.\n'
+             'Default is "{workspace_name}" (the tag will be the same as the workspace name).'
+        )
 @option('-o', '--pip-install-options', required=False,
         type=str, multiple=True, default=tuple,
         help='Options for remote pip install. '
@@ -451,7 +457,7 @@ def dockerize_(context, base_image, save):
         help='Dump the Docker image to an archive')
 @option('--rebuild', help='Build images with `--no-cache`', is_flag=True)
 @pass_context
-def graminize_(context, signing_key: Path, enclave_size: str, pip_install_options: Tuple[str],
+def graminize_(context, signing_key: Path, enclave_size: str, tag: str, pip_install_options: Tuple[str],
                save: bool, rebuild: bool) -> None:
     """
     Build gramine app inside a docker image.
@@ -504,10 +510,12 @@ def graminize_(context, signing_key: Path, enclave_size: str, pip_install_option
 
     grainized_ws_dockerfile = SITEPACKS / 'openfl-gramine' / 'Dockerfile.graminized.workspace'
 
+    tag = tag.format(workspace_name=workspace_name)
+
     echo('\n 🐋 Building graminized workspace image...')
     signing_key = f'--secret id=signer-key,src={signing_key} ' if sgx_build else ''
     graminized_build_command = (
-        f'docker build -t {workspace_name} {rebuild_option} '
+        f'docker build -t {tag} {rebuild_option} '
         '--build-arg BASE_IMAGE=gramine_openfl '
         f'--build-arg WORKSPACE_ARCHIVE={workspace_archive.relative_to(workspace_path)} '
         f'--build-arg SGX_ENCLAVE_SIZE={enclave_size} '
@@ -519,9 +527,9 @@ def graminize_(context, signing_key: Path, enclave_size: str, pip_install_option
 
     if save:
         echo('\n 💾 Saving the graminized workspace image...')
-        save_image_command = f'docker save {workspace_name} | gzip > {workspace_name}.tar.gz'
+        save_image_command = f'docker save {tag} | gzip > {tag}.tar.gz'
         open_pipe(save_image_command)
-        echo(f'\n ✔️ The image saved to file: {workspace_name}.tar.gz')
+        echo(f'\n ✔️ The image saved to file: {tag}.tar.gz')
 
 
 def apply_template_plan(prefix, template):


### PR DESCRIPTION
Set the graminized image name in "fx workspace graminize" using the "-t"
argument. The tag name is formatted with the "worspace_name" input, such
that "{workspace_name}" format specifier in the tag name will be replace
by the workspace name

If not specified, the workspace name will be used as tag (current
behavior)

Signed-off-by: Lavi, Nir <nir.lavi@intel.com>